### PR TITLE
Support using a BSD style "stat" command

### DIFF
--- a/zsh-reentry-hook.plugin.zsh
+++ b/zsh-reentry-hook.plugin.zsh
@@ -6,8 +6,19 @@
 [[ -o interactive ]] || return #interactive only
 autoload -Uz add-zsh-hook || { print "can't add zsh hook!"; return }
 
+if stat --version && stat --version | grep GNU ; then
+	reentry_hook_stat () {
+		stat -c '%h' .
+	}
+else
+	# Assume that we are dealing with a BSD variant.
+	reentry_hook_stat () {
+		stat -f '%l' .
+	}
+fi
+
 reentry_hook() {
-    if [[ `stat -c "%h" .` -eq 0 && -d "$PWD" ]]; then
+    if [[ `reentry_hook_stat` -eq 0 && -d "$PWD" ]]; then
         builtin cd .
     fi
 }


### PR DESCRIPTION
This patch checks whether `stat` is the GNU version, and if that is not the case, the command arguments are changed to work with a BSD version of the command.

Tested in DragonflyBSD. Also, checked the manual pages for other BSDs, and they all seem to support `-f '%l'`:
- MacOS X: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/stat.1.html
- OpenBSD: http://www.openbsd.org/cgi-bin/man.cgi?query=stat
- FreeBSD: http://www.freebsd.org/cgi/man.cgi?query=stat
- NetBSD: http://netbsd.gw.com/cgi-bin/man-cgi?stat
