### PR TITLE
Mute stdout when detecting which stat variant is being used

### DIFF
--- a/zsh-reentry-hook.plugin.zsh
+++ b/zsh-reentry-hook.plugin.zsh
@@ -6,7 +6,7 @@
 [[ -o interactive ]] || return #interactive only
 autoload -Uz add-zsh-hook || { print "can't add zsh hook!"; return }
 
-if stat --version && stat --version | grep GNU ; then
+if stat --version &> /dev/null && [[ -n $(stat --version |& grep GNU) ]] ; then
 	reentry_hook_stat () {
 		stat -c '%h' .
 	}


### PR DESCRIPTION
Also, redirect the stderr of second invocation to stdout, in case the
behaviour of the tool changes at some point and the text to be grepped
for ends up in stderr.
